### PR TITLE
fix: prevent panics in hciconfig/netstat parsers on truncated input

### DIFF
--- a/crates/jc-rs-parsers/src/misc/hciconfig.rs
+++ b/crates/jc-rs-parsers/src/misc/hciconfig.rs
@@ -123,7 +123,7 @@ impl Parser for HciconfigParser {
                     // RX bytes:1307 acl:0 sco:0 events:51 errors:0
                     let clean = trimmed.replace(':', " ");
                     let parts: Vec<&str> = clean.split_whitespace().collect();
-                    if parts.len() >= 10 {
+                    if parts.len() >= 11 {
                         d.insert("rx_bytes".to_string(), int_val(parts[2]));
                         d.insert("rx_acl".to_string(), int_val(parts[4]));
                         d.insert("rx_sco".to_string(), int_val(parts[6]));
@@ -134,7 +134,7 @@ impl Parser for HciconfigParser {
                     // TX bytes:1200 acl:0 sco:0 commands:51 errors:0
                     let clean = trimmed.replace(':', " ");
                     let parts: Vec<&str> = clean.split_whitespace().collect();
-                    if parts.len() >= 10 {
+                    if parts.len() >= 11 {
                         d.insert("tx_bytes".to_string(), int_val(parts[2]));
                         d.insert("tx_acl".to_string(), int_val(parts[4]));
                         d.insert("tx_sco".to_string(), int_val(parts[6]));
@@ -287,6 +287,21 @@ mod tests {
             assert!(arr.is_empty());
         } else {
             panic!("Expected Array");
+        }
+    }
+
+    #[test]
+    fn test_hciconfig_truncated_rx_tx_line() {
+        // A truncated "RX bytes:"/"TX bytes:" line (e.g. output cut off mid-line)
+        // yields exactly 10 whitespace-separated parts after the ':' replacement,
+        // but the parser indexed parts[10]. This must not panic.
+        let parser = HciconfigParser;
+        for stat in ["RX", "TX"] {
+            let input = format!(
+                "hci0:\tType: Primary  Bus: USB\n\t{stat} bytes:1307 acl:0 sco:0 events:51 errors"
+            );
+            // Should return a result without panicking.
+            let _ = parser.parse(&input, false).unwrap();
         }
     }
 }

--- a/crates/jc-rs-parsers/src/network/netstat.rs
+++ b/crates/jc-rs-parsers/src/network/netstat.rs
@@ -339,7 +339,7 @@ fn linux_parse_socket(
     if state_col != usize::MAX {
         let ch = entry.chars().nth(state_col);
         let is_blank = ch.map(|c| c.is_whitespace()).unwrap_or(false);
-        if is_blank {
+        if is_blank && tokens.len() >= 4 {
             tokens.insert(4, None);
         }
     }
@@ -715,13 +715,18 @@ fn bsd_parse_item(
             tokens.insert(1, String::new());
         } else if has_state_col && is_udp_first && !has_socket_col {
             // Standard: state column missing for UDP; insert at position 5
-            if tokens.len() < headers.len() {
+            if tokens.len() < headers.len() && tokens.len() >= 5 {
                 tokens.insert(5, String::new());
             }
         }
         // socket column present (netstat -An/-Aa style): UDP missing state at position 7
         // Python: if 'socket' in headers and 'udp' in str(entry): entry.insert(7, None)
-        if has_socket_col && is_udp_any && !has_0win_col && tokens.len() < headers.len() {
+        if has_socket_col
+            && is_udp_any
+            && !has_0win_col
+            && tokens.len() < headers.len()
+            && tokens.len() >= 7
+        {
             tokens.insert(7, String::new());
         }
     }
@@ -1198,5 +1203,30 @@ mod tests {
     #[test]
     fn test_netstat_registered() {
         assert!(jc_rs_core::registry::find_parser("netstat").is_some());
+    }
+
+    #[test]
+    fn test_netstat_truncated_udp_line() {
+        // Command output cut off mid-line (e.g. a closed pipe) can leave a UDP
+        // row with far fewer columns than the header. The UDP column-normalizing
+        // inserts (at fixed positions 5 and 7) must not panic when the row is
+        // shorter than that position.
+        let inputs = [
+            // BSD-style header, then a truncated udp row.
+            "Active Internet connections (including servers)\n\
+             Proto Recv-Q Send-Q Local Address          Foreign Address        (state)\n\
+             udp4       0",
+            "Active Internet connections (including servers)\n\
+             Proto Recv-Q Send-Q Local Address          Foreign Address        (state)\n\
+             udp",
+            // Socket-address style header with a short udp row.
+            "Active Internet connections (servers and established)\n\
+             Proto Recv-Q Send-Q Local Address Foreign Address State PID/Program name Path\n\
+             udp 0",
+        ];
+        for input in inputs {
+            // Must return a result rather than panicking.
+            let _ = NetstatParser.parse(input, false).unwrap();
+        }
     }
 }


### PR DESCRIPTION
## What

Two parsers panic on truncated input. Both process command output that can legitimately be cut off mid-line (a closed pipe, a killed command, `head`-ed output), so a truncated line should produce a parse result — not a crash.

### `hciconfig`

The `RX bytes:` / `TX bytes:` handlers guard `parts.len() >= 10` but then index `parts[10]`, which needs at least 11 elements:

```rust
if parts.len() >= 10 {
    ...
    d.insert("rx_errors".to_string(), int_val(parts[10])); // needs len >= 11
}
```

A line truncated at `RX bytes:1307 acl:0 sco:0 events:51 errors` (no value after `errors`) becomes exactly 10 whitespace parts after the `:`→` ` replacement, so `parts[10]` panics:

```
index out of bounds: the len is 10 but the index is 10
```

### `netstat`

The UDP column-normalizing code inserts placeholder columns at fixed positions:

```rust
tokens.insert(5, String::new());   // guarded only against headers.len()
tokens.insert(7, String::new());   // guarded only against headers.len()
tokens.insert(4, None);            // not guarded at all
```

`Vec::insert(i, _)` requires `i <= len`. A short UDP row (e.g. output cut off at `udp4       0`) has far fewer tokens than the header, so these panic:

```
insertion index (is 5) should be <= len (is 2)
insertion index (is 7) should be <= len (is 4)
```

## Fix

- `hciconfig`: change both guards to `parts.len() >= 11`.
- `netstat`: require the token vector to already be long enough before each positional insert (`tokens.len() >= 5` / `>= 7` / `>= 4`).

## Testing

Added focused regression tests to both parsers (`test_hciconfig_truncated_rx_tx_line`, `test_netstat_truncated_udp_line`) built from truncated sample lines. Verified RED→GREEN — reverting the guards reproduces the exact panics above; with the fix, the parsers return a result. Existing golden-fixture tests for both parsers still pass, and `cargo fmt`/`clippy` are clean on the changed files.

## How it was found

By feeding truncated prefixes of the repo's own `tests/fixtures/*.out` files to every registered parser and asserting none panic (via `catch_unwind`). Only these two parsers crashed.
